### PR TITLE
Fixes Issue #14: Added navbar-item for link to home page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,6 +16,11 @@
     <div class="navbar-menu" id="navMenu">
         <div class="navbar-start"></div>
         <div class="navbar-end ">
+            <div class="navbar-item has-dropdown is-hoverable">
+                <a class="navbar-link is-arrowless" href="/">
+                    Home
+                </a>
+            </div>
             {% assign mydocs = site.html_pages | group_by: 'dir' %}
             {% for cat in mydocs %}
             {% unless cat.name == "/" or cat.name contains "announcements"%}


### PR DESCRIPTION
I've added a navbar-item that the user sees as "Home" on the navbar and can click to go back to the main page. The home item has "has-dropdown is-hoverable" to maintain consistency with the ui of the other navbar items when hovered over, but doesn't actually include any dropdown items.