### PR TITLE
Fixes Issue #15: Changed Navbar so that when you click on a dropdown category, it redirects you to the first item in the dropdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,4 +4,3 @@ paginate: 5
 paginate_path: "/announcements/:num/"
 
 timezone: America/New_York
-

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,7 +20,8 @@
             {% for cat in mydocs %}
             {% unless cat.name == "/" or cat.name contains "announcements"%}
             <div class="navbar-item has-dropdown is-hoverable">
-                <a class="navbar-link">
+                {% assign firstItem = cat.items | first %}
+                <a class="navbar-link" href="{{ firstItem.url }}">
                     {% assign titlewords = cat.name | remove: "/" | split: "-" %}
                     {% for titleword in titlewords %}
                     {{ titleword | capitalize | replace: "The","the" }}


### PR DESCRIPTION
I changed the nav.html file so that when a user clicks on a Navbar category (Such as "Academics" or "About Us") the user is automatically redirected to the first option on the dropdown. Additionally, I changed the tab naming so that when the user is on the home page, they see "Skule TM" instead of "Skule TM -". 